### PR TITLE
switch from Path::Slurp::Tiny to Path::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2020-10-??  jmerelo  <jmerelo@princess-carolyn>
+
+    * switch from File::Slurp::Tiny to Path::Tiny
+
 2020-10-10  jmerelo  <jmerelo@princess-carolyn>
 
 	* lib/Test/Text.pm: 0.6.4 includes multi-line markdown links.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
     PREREQ_PM => {
 		  'Test::More' => 0,
 		  'version'    => 0,
-		  'File::Slurp::Tiny' => 0,
+		  'Path::Tiny' => 0.111,
 		  'Text::Hunspell' => 2.08,
 		  'Encode' => 0,
 		  'Test::Simple' => 1.0 #base class 

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'Test::More';
 requires 'version';
-requires 'File::Slurp::Tiny';
+requires 'Path::Tiny', '0.111';
 requires 'Text::Hunspell';
 requires 'Encode';
 requires 'Test::Simple', '>=1.0'; #base class 

--- a/lib/Test/Text.pm
+++ b/lib/Test/Text.pm
@@ -6,7 +6,7 @@ use utf8; # Files and dictionaries might use utf8
 use Encode;
 
 use Carp;
-use File::Slurp::Tiny 'read_file';
+use Path::Tiny;
 use Text::Hunspell;
 use Test::Text::Sentence qw(split_sentences);
 use v5.22;
@@ -68,7 +68,7 @@ sub check {
   my %vocabulary;
   my @sentences;
   for my $f ( @{$self->files}) {
-    my $file_content= read_file($f, binmode => ':utf8');
+    my $file_content= path($f)->slurp_utf8;
     if ( $f =~ /(\.md|\.markdown)/ ) {
       $file_content = _strip_urls( $file_content);
       $file_content = _strip_code( $file_content);

--- a/t/011-split-sentences.t
+++ b/t/011-split-sentences.t
@@ -5,7 +5,7 @@ use warnings;
 use utf8;
 
 use Test::More;
-use File::Slurp::Tiny 'read_file';
+use Path::Tiny;
 use Test::Text::Sentence qw(split_sentences);
 
 my $dir = 'text/en';
@@ -16,7 +16,7 @@ if ( !-e $dir ) {
 my @files = glob("$dir/*.md $dir/*.tex $dir/*.txt $dir/*.markdown)");
 
 for my $f ( @files ) {
-  my @sentences = split_sentences( read_file($f) );
+  my @sentences = split_sentences( path($f)->slurp_utf8 );
   ok( @sentences, "Splits in sentences" );
   cmp_ok( $#sentences, ">=", 0, "There's at least one sentence");
 }


### PR DESCRIPTION
Hi JJ,

This PR deals with #11 – switching from File::Slurp::Tiny to Path::Tiny.

I use File::Slurper for slurping these days, but I saw your comment on the existing dependency.

Cheers,
Neil
