### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,74 +1,69 @@
-2020-10-??  jmerelo  <jmerelo@princess-carolyn>
+Revision history for Perl module Test::Text
 
+0.6.5   2020-10-??  JMERELO
     * switch from File::Slurp::Tiny to Path::Tiny
+    * Reformatted Changes as per CPAN::Changes::Spec
 
-2020-10-10  jmerelo  <jmerelo@princess-carolyn>
-
+0.6.4   2020-10-10  JMERELO
 	* lib/Test/Text.pm: 0.6.4 includes multi-line markdown links.
 
-2020-09-21  jmerelo  <jmerelo@princess-carolyn>
+0.6.3   2020-09-21  JMERELO
+	* lib/Test/Text.pm: Changes again so that it can be called
+      with or without calling done_testing.
 
-	* lib/Test/Text.pm: Changes again so that it can be called with or without calling done_testing.
+0.6.2   2020-09-21  JMERELO
+	* lib/Test/Text.pm: New version eliminates done_testing from the check;
+      this will break a few things, I'm afraid... 
+    * Added optional done_testing with a 4th argument to just_check.
+      It's on by default, can be turned off.
 
-2020-09-21  jmerelo  <jmerelo@jjmerelo-System-Product-Name>
+0.6.1   2019-10-31  JMERELO
+	* lib/Test/Text.pm: Latest version includes Text::Sentence
+      (taken from HTML::Summary) to avoid installation of all dependencies
+      in that module.
 
-	* lib/Test/Text.pm: New version eliminates done_testing from the check; this will break a few things, I'm afraid... 
-	Adde optional done_testing with a 4th argument to just_check. It's on by default, can be turned off.
-
-2019-10-31  Juan J. merelo  <jmerelo@penny>
-
-	* lib/Test/Text.pm: Latest version includes Text::Sentence (taken from HTML::Summary) to avoid installation of all dependencies in that module.
-
-2017-07-28  Juan J. merelo  <jmerelo@penny>
-
+0.4.2   2017-07-28  JMERELO
 	* lib/Test/Text.pm: Shows correctly (apparently) utf-8 encoded characters.
 
-2016-04-20  Juan J. merelo  <jmerelo@penny>
-
+0.4.0   2016-04-20  JMERELO
 	* lib/Test/Text.pm: Strips code from markdown to avoid getting
-	bogged down by it. 
+	  bogged down by it. 
 
-2015-12-20  Juan J. merelo  <jmerelo@penny>
-
+0.3.0   2015-12-20  JMERELO
 	* lib/Test/Text.pm (check): Strips URL to avoid oh so many
-	non-dict words to creep up in the text. 
+	  non-dict words to creep up in the text. 
 
-2014-08-16  JJ Merelo  <jmerelo@amy>
+0.1.8   2014-08-16  JMERELO
+    * lib/Test/Text.pm: Many patches from Gabor Szabo
+      and eliminated File::Slurp dependency.
+    * Also suppressed legacy "uses"
 
-	* lib/Test/Text.pm: Many patches from Gabor Szabo and eliminated File::Slurp dependency. Also suppressed legacy "uses"
-
-2014-08-13  JJ Merelo  <jmerelo@amy>
-
+0.1.7   2014-08-13  JMERELO
 	* t/02.just_check.t: Added this since it's got an independent done_testing
+	* lib/Test/Text.pm (just_check): Finished tests and changed encoding
+      for test script.
 
-	* lib/Test/Text.pm (just_check): Finished tests and changed encoding for test script.
-
-2014-08-12  JJ Merelo  <jmerelo@amy>
-
+0.1.6   2014-08-12  JMERELO
 	* lib/Test/Text.pm (check): Adds more strict extraction of words
-	to avoid some Spanish sigils; changes tests to account for that.
-	(check): getting rid of old regexes and using proper Unicode for version 0.1.5
+	  to avoid some Spanish sigils; changes tests to account for that.
+	  (check): getting rid of old regexes and using proper Unicode for
+               version 0.1.5
 
-2014-08-11  JJ Merelo  <jmerelo@amy>
+0.1.3   2014-08-11  JMERELO
+	* lib/Test/Text.pm: Adds a few Spanish symbols to avoid UTF8 errors
+      and corrects the Spanish affix file to avoid warnings. 
 
-	* lib/Test/Text.pm: Adds a few Spanish symbols to avoid UTF8 errors and corrects the Spanish affix file to avoid warnings. 
-
-2014-08-10  JJ Merelo  <jmerelo@amy>
-
+0.1.2   2014-08-10   JMERELO
 	* lib/Test/Text.pm (done_testing): Managed to make it work with
-	UTF8 dictionaries, passing now tests. Will try to use it in actual
-	CI for my latest book
+	  UTF8 dictionaries, passing now tests. Will try to use it in actual
+	  CI for my latest book
 
-2014-08-08  JJ Merelo  <jmerelo@amy>
-
+0.1.0   2014-08-08   JMERELO
 	* lib/Test/Text.pm: Added text and data for Spanish. 
 
-2014-05-01  Juan J. Merelo Guervós  <jjmerelo@gmail.com>
-
+0.0.4   2014-05-02   JMERELO
 	* MANIFEST: Changing manifest for the new version
 
-Revision history for Text-Hoborg
-
-0.0.1  Mon May 27 07:59:10 2013
-       Initial release.
+0.0.1   2013-05-27  JMERELO
+    * Initial release.
 


### PR DESCRIPTION
Hi JJ,

This addresses #20, reformatting the Changes file to follow the accepted convention. The main advantage of this is that MetaCPAN will display the changes in the most recent release, when you look at the dist page.

Cheers,
Neil
